### PR TITLE
Add Color Thresholds and Always Show Options

### DIFF
--- a/src/main/java/com/hpabovehead/HPAboveHeadConfig.java
+++ b/src/main/java/com/hpabovehead/HPAboveHeadConfig.java
@@ -10,7 +10,8 @@ public interface HPAboveHeadConfig extends Config
 	@ConfigItem(
 			keyName = "fontSize",
 			name = "Font Size",
-			description = "Size of the text above the HP bar"
+			description = "Size of the text above the HP bar",
+			position = 0
 	)
 	@Range(min = 8, max = 40)
 	default int fontSize()
@@ -18,7 +19,158 @@ public interface HPAboveHeadConfig extends Config
 		return 14;
 	}
 
-	public enum FontOption
+	@ConfigItem(
+			keyName = "font",
+			name = "Font",
+			description = "Font used for the text",
+			position = 1
+	)
+	default FontOption font()
+	{
+		return FontOption.VERDANA;
+	}
+	
+	@ConfigItem(
+			keyName = "color",
+			name = "Text Color",
+			description = "Color of the text above the HP bar",
+			position = 2
+	)
+	default Color color()
+	{
+		return Color.GREEN;
+	}
+
+	@ConfigItem(
+			keyName = "textHeightOffset",
+			name = "Text vertical offset",
+			description = "How high above the HP bar to render the HP text",
+			position = 3
+	)
+	default int textHeightOffset()
+	{
+		return 47;
+	}
+
+	@ConfigItem(
+			keyName = "textXOffset",
+			name = "Text horizontal offset",
+			description = "Horizontal offset for the HP text relative to the player's center",
+			position = 4
+	)
+	default int textXOffset()
+	{
+		return 0;
+	}
+
+	@ConfigItem(
+			keyName = "showBackground",
+			name = "Show Background",
+			description = "Draw a background behind the HP text",
+			position = 5
+	)
+	default boolean showBackground()
+	{
+		return true;
+	}
+
+	@Alpha
+	@ConfigItem(
+			keyName = "backgroundColor",
+			name = "Background Color",
+			description = "Color of the HP text background",
+			position = 6
+	)
+	default Color backgroundColor()
+	{
+		return new Color(0, 0, 0, 125); // semi-transparent black
+	}
+
+	@ConfigItem(
+			keyName = "alwaysShow",
+			name = "Always Show",
+			description = "Always show HP text, even when not in combat",
+			position = 7
+	)
+	default boolean alwaysShow()
+	{
+		return false;
+	}
+
+	@ConfigSection(
+			name = "Color Thresholds",
+			description = "Settings for color thresholds based on HP percentage",
+			position = 8,
+			closedByDefault = true
+	)
+	String colorThresholds = "colorThresholds";
+
+
+	@ConfigItem(
+			keyName = "useColorThresholds",
+			name = "Use Color Thresholds",
+			description = "Change text color based on HP percentage",
+			position = 9,
+			section = colorThresholds
+	)
+	default boolean useColorThresholds()
+	{
+		return false;
+	}
+
+	@ConfigItem(
+			keyName = "midThreshold",
+			name = "Mid HP Threshold (%)",
+			description = "HP percentage below which text color changes to mid HP color",
+			position = 10,
+			section = colorThresholds
+	)
+	@Range(min = 1, max = 100)
+	default int midThreshold()
+	{
+		return 50;
+	}
+
+	@ConfigItem(
+			keyName = "midColor",
+			name = "Mid HP color",
+			description = "Color to use when HP is below mid threshold",
+			position = 11,
+			section = colorThresholds
+	)
+	default Color midColor()
+	{
+		return Color.YELLOW;
+	}
+
+	@ConfigItem(
+			keyName = "lowThreshold",
+			name = "Low HP Threshold (%)",
+			description = "HP percentage below which text color changes to low HP color",
+			position = 12,
+			section = colorThresholds
+	)
+	@Range(min = 1, max = 100)
+	default int lowThreshold()
+	{
+		return 25;
+	}
+
+	@ConfigItem(
+			keyName = "lowColor",
+			name = "Low HP color",
+			description = "Color to use when HP is below low threshold",
+			position = 13,
+			section = colorThresholds
+	)
+	default Color lowColor()
+	{
+		return Color.RED;
+	}
+
+	/* enums */
+
+	enum FontOption
 	{
 		ARIAL,
 		VERDANA,
@@ -34,67 +186,6 @@ public interface HPAboveHeadConfig extends Config
 		LUCIDA_CONSOLE,
 		ROBOTO
 
-	}
-
-	@ConfigItem(
-			keyName = "font",
-			name = "Font",
-			description = "Font used for the text"
-	)
-	default FontOption font()
-	{
-		return FontOption.VERDANA;
-	}
-
-	@ConfigItem(
-			keyName = "color",
-			name = "Text Colour",
-			description = "Colour of the text above the HP bar"
-	)
-	default Color color()
-	{
-		return Color.GREEN;
-	}
-
-	@ConfigItem(
-			keyName = "textHeightOffset",
-			name = "Text vertical offset",
-			description = "How high above the HP bar to render the HP text"
-	)
-	default int textHeightOffset()
-	{
-		return 47;
-	}
-
-	@ConfigItem(
-			keyName = "textXOffset",
-			name = "Text horizontal offset",
-			description = "Horizontal offset for the HP text relative to the player's centre"
-	)
-	default int textXOffset()
-	{
-		return 0;
-	}
-
-	@ConfigItem(
-			keyName = "showBackground",
-			name = "Show Background",
-			description = "Draw a background behind the HP text"
-	)
-	default boolean showBackground()
-	{
-		return true;
-	}
-
-	@Alpha
-	@ConfigItem(
-			keyName = "backgroundColor",
-			name = "Background Colour",
-			description = "Colour of the HP text background"
-	)
-	default Color backgroundColor()
-	{
-		return new Color(0, 0, 0, 125); // semi-transparent black
 	}
 
 }

--- a/src/main/java/com/hpabovehead/HPAboveHeadConfig.java
+++ b/src/main/java/com/hpabovehead/HPAboveHeadConfig.java
@@ -1,8 +1,13 @@
 package com.hpabovehead;
 
-import net.runelite.client.config.*;
+import net.runelite.client.config.ConfigGroup;
+import net.runelite.client.config.ConfigItem;
+import net.runelite.client.config.ConfigSection;
+import net.runelite.client.config.Config;
+import net.runelite.client.config.Alpha;
+import net.runelite.client.config.Range;
 
-import java.awt.*;
+import java.awt.Color;
 
 @ConfigGroup("settings")
 public interface HPAboveHeadConfig extends Config

--- a/src/main/java/com/hpabovehead/HPAboveHeadOverlay.java
+++ b/src/main/java/com/hpabovehead/HPAboveHeadOverlay.java
@@ -31,7 +31,13 @@ public class HPAboveHeadOverlay extends Overlay
     public Dimension render(Graphics2D g)
     {
         Player localPlayer = client.getLocalPlayer();
-        if (localPlayer == null || localPlayer.getHealthScale() <= 0)
+        if (localPlayer == null)
+        {
+            return null;
+        }
+
+        // Check if we should show HP - either always show is enabled, or player is in combat (health scale > 0)
+        if (!config.alwaysShow() && localPlayer.getHealthScale() <= 0)
         {
             return null;
         }
@@ -74,11 +80,40 @@ public class HPAboveHeadOverlay extends Overlay
             g.setColor(Color.BLACK);
             g.drawString(text, x + 1, y + 1);
 
-            // HP text
-            g.setColor(config.color());
+            // HP text with color thresholds
+            Color textColor = getTextColor(currentHp, maxHp);
+            g.setColor(textColor);
             g.drawString(text, x, y);
         }
 
         return null;
+    }
+
+    /**
+     * Determines the text color based on HP percentage and threshold settings
+     */
+    private Color getTextColor(int currentHp, int maxHp)
+    {
+        if (!config.useColorThresholds())
+        {
+            return config.color();
+        }
+
+        // Calculate HP percentage
+        double hpPercentage = (double) currentHp / maxHp * 100;
+
+        // Apply color thresholds (low has priority over mid)
+        if (hpPercentage <= config.lowThreshold())
+        {
+            return config.lowColor();
+        }
+        else if (hpPercentage <= config.midThreshold())
+        {
+            return config.midColor();
+        }
+        else
+        {
+            return config.color();
+        }
     }
 }

--- a/src/main/java/com/hpabovehead/HPAboveHeadOverlay.java
+++ b/src/main/java/com/hpabovehead/HPAboveHeadOverlay.java
@@ -3,11 +3,13 @@ package com.hpabovehead;
 import net.runelite.api.Client;
 import net.runelite.api.Perspective;
 import net.runelite.api.Player;
+import net.runelite.api.Point;
 import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.OverlayLayer;
 import net.runelite.client.ui.overlay.OverlayPosition;
 import net.runelite.client.ui.overlay.OverlayPriority;
 import net.runelite.api.Skill;
+import net.runelite.api.coords.LocalPoint;
 
 import javax.inject.Inject;
 import java.awt.Color;
@@ -20,6 +22,12 @@ public class HPAboveHeadOverlay extends Overlay
 {
     private final Client client;
     private final HPAboveHeadConfig config;
+    
+    // Animation state
+    private Color currentColor;
+    private Color targetColor;
+    private long transitionStartTime;
+    private static final long TRANSITION_DURATION_MS = 200;
 
     @Inject
     public HPAboveHeadOverlay(Client client, HPAboveHeadConfig config)
@@ -29,6 +37,9 @@ public class HPAboveHeadOverlay extends Overlay
         setPosition(OverlayPosition.DYNAMIC);
         setLayer(OverlayLayer.ALWAYS_ON_TOP);
         setPriority(OverlayPriority.MED);
+        this.currentColor = null;
+        this.targetColor = null;
+        this.transitionStartTime = 0;
     }
 
     @Override
@@ -55,19 +66,16 @@ public class HPAboveHeadOverlay extends Overlay
         FontMetrics metrics = g.getFontMetrics();
         int textWidth = metrics.stringWidth(text);
         int textHeight = metrics.getHeight();
-
-        // calc height (player's logical height + offset)
         int height = localPlayer.getLogicalHeight() + config.textHeightOffset();
-        net.runelite.api.coords.LocalPoint localLocation = localPlayer.getLocalLocation();
-        net.runelite.api.Point canvasPoint = Perspective.localToCanvas(client, localLocation, client.getPlane(), height);
+        LocalPoint localLocation = localPlayer.getLocalLocation();
+        Point canvasPoint = Perspective.localToCanvas(client, localLocation, client.getPlane(), height);
 
         if (canvasPoint != null)
         {
-            // centre the text and apply horizontal offset
             int x = canvasPoint.getX() - (textWidth / 2) + config.textXOffset();
             int y = canvasPoint.getY();
 
-            // optional background box
+            // Draw background if enabled
             if (config.showBackground())
             {
                 int padding = 2;
@@ -80,44 +88,117 @@ public class HPAboveHeadOverlay extends Overlay
                 g.fillRect(boxX, boxY, boxWidth, boxHeight);
             }
 
-            // optional shadow
+            // Get color based on HP percentage and thresholds
+            Color textColor = getTextColor(currentHp, maxHp);
+
+            // Draw shadow
             g.setColor(Color.BLACK);
             g.drawString(text, x + 1, y + 1);
 
-            // HP text with color thresholds
-            Color textColor = getTextColor(currentHp, maxHp);
+            // Draw main text
             g.setColor(textColor);
             g.drawString(text, x, y);
-        }
 
+        }
+        
         return null;
     }
 
     /**
-     * Determines the text color based on HP percentage and threshold settings
+     * Determines the text color based on HP percentage and threshold settings.
+     * Smoothly fades between colors when crossing thresholds.
      */
     private Color getTextColor(int currentHp, int maxHp)
     {
         if (!config.useColorThresholds())
         {
+            // Reset animation state if thresholds are disabled
+            currentColor = null;
             return config.color();
         }
 
-        // Calculate HP percentage
-        double hpPercentage = (double) currentHp / maxHp * 100;
+        double hpPercent = (double) currentHp / maxHp * 100;
+        int lowThreshold = config.lowThreshold();
+        int midThreshold = config.midThreshold();
 
-        // Apply color thresholds (low has priority over mid)
-        if (hpPercentage <= config.lowThreshold())
+        // Determine what the target color should be based on HP percentage
+        Color newTargetColor;
+        if (hpPercent <= lowThreshold)
         {
-            return config.lowColor();
+            newTargetColor = config.lowColor();
         }
-        else if (hpPercentage <= config.midThreshold())
+        else if (hpPercent <= midThreshold)
         {
-            return config.midColor();
+            newTargetColor = config.midColor();
         }
         else
         {
-            return config.color();
+            newTargetColor = config.color();
         }
+
+        // Initialize or detect color change
+        if (currentColor == null)
+        {
+            // First render, no animation needed
+            currentColor = newTargetColor;
+            targetColor = newTargetColor;
+            return currentColor;
+        }
+
+        // Check if target color has changed (threshold crossed)
+        if (!newTargetColor.equals(targetColor))
+        {
+            // Start a new transition
+            currentColor = getAnimatedColor(); // Get the current animated color
+            targetColor = newTargetColor;
+            transitionStartTime = System.currentTimeMillis();
+        }
+
+        return getAnimatedColor();
+    }
+
+    /**
+     * Calculates the current color during a transition animation
+     * @return The interpolated color based on elapsed time
+     */
+    private Color getAnimatedColor()
+    {
+        if (currentColor == null || targetColor == null || currentColor.equals(targetColor))
+        {
+            return targetColor != null ? targetColor : config.color();
+        }
+
+        long elapsedTime = System.currentTimeMillis() - transitionStartTime;
+        
+        if (elapsedTime >= TRANSITION_DURATION_MS)
+        {
+            // Transition complete
+            currentColor = targetColor;
+            return currentColor;
+        }
+
+        // Calculate interpolation position (0.0 to 1.0)
+        double progress = (double) elapsedTime / TRANSITION_DURATION_MS;
+        return interpolateColor(currentColor, targetColor, progress);
+    }
+
+    /**
+     * Interpolates between two colors based on a position value (0.0 to 1.0)
+     * @param color1 Starting color
+     * @param color2 Ending color
+     * @param position Position between colors (0.0 = color1, 1.0 = color2)
+     * @return Interpolated color
+     */
+    private Color interpolateColor(Color color1, Color color2, double position)
+    {
+        // Clamp position between 0 and 1
+        position = Math.max(0.0, Math.min(1.0, position));
+
+        int r = (int) (color1.getRed() + (color2.getRed() - color1.getRed()) * position);
+        int g = (int) (color1.getGreen() + (color2.getGreen() - color1.getGreen()) * position);
+        int b = (int) (color1.getBlue() + (color2.getBlue() - color1.getBlue()) * position);
+        int a = (int) (color1.getAlpha() + (color2.getAlpha() - color1.getAlpha()) * position);
+
+        return new Color(r, g, b, a);
     }
 }

--- a/src/main/java/com/hpabovehead/HPAboveHeadOverlay.java
+++ b/src/main/java/com/hpabovehead/HPAboveHeadOverlay.java
@@ -10,7 +10,11 @@ import net.runelite.client.ui.overlay.OverlayPriority;
 import net.runelite.api.Skill;
 
 import javax.inject.Inject;
-import java.awt.*;
+import java.awt.Color;
+import java.awt.Dimension;
+import java.awt.Font;
+import java.awt.FontMetrics;
+import java.awt.Graphics2D;
 
 public class HPAboveHeadOverlay extends Overlay
 {


### PR DESCRIPTION
### Hallo!! I've added some new features and I'd love for you to have a looksie


**Animated Color Thresholds**

- HP text color changes dynamically based on configurable percentage thresholds
- Mid HP threshold (default: 50%) and Low HP threshold (default: 25%)
- Customizable colors for each threshold level

**Always Show Option**
- Toggle to keep HP text visible regardless of combat state
- Previously only displayed during combat (`healthScale > 0`)
- I think this is useful for people who are constantly scared of dying, we could change this to hide after x seconds outside of combat
<br>

### Configuration Panel

#### All config items now have proper position attributes for logical ordering:
- Font & Styling (0-2)
- Positioning (3-4)
- Display Options (5-7)
- Color Thresholds Section (8-13, collapsible)

### Code Quality
- Added Javadoc comments for all helper methods
- Clean state management for animation


_**Note:** Normalized import statements and removed wildcard imports for better code clarity._
